### PR TITLE
fix: update Node.js version requirement for semantic-release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '18.x'
+          node-version: '20.x'
           cache: 'npm'
           
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '18.x'
+          node-version: '20.x'
           cache: 'npm'
 
       - name: Install dependencies

--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ ESLint rules to provide warnings and guardrails for AI coding assistance
 npm install eslint-plugin-vibe-check --save-dev
 ```
 
+### Requirements
+
+- Node.js >=20.8.1
+- ESLint >=8.0.0
+
 ## Usage
 
 ### Traditional Config (`.eslintrc`)

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "homepage": "https://github.com/cahaseler/eslint-plugin-vibe-check#readme",
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=20.8.1"
   },
   "peerDependencies": {
     "eslint": ">=8.0.0"


### PR DESCRIPTION
## Description

This PR updates the Node.js version requirement to >=20.8.1, which is needed for semantic-release to function properly.

## Changes
- Update GitHub Actions workflows to use Node.js 20.x 
- Update engines field in package.json to require Node.js >=20.8.1
- Add Node.js version requirement to README.md

## Motivation
semantic-release requires Node.js >=20.8.1, as noted in the error message:


This PR ensures the CI/CD pipeline uses the correct version.