### PR TITLE
fix: add required permissions for semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,12 +9,18 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write      # to create releases and publish
+      issues: write        # to create issues
+      pull-requests: write # to comment on PRs
+      id-token: write      # for npm provenance
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          persist-credentials: false
+          # Use GITHUB_TOKEN with the proper permissions
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v3


### PR DESCRIPTION
## Description

This PR fixes the permissions issue with semantic-release by adding the necessary permissions to the GitHub workflow.

## Changes

- Add explicit permissions to the GitHub workflow:
  -  - to create releases and tags
  -  - to create issues for error reporting
  -  - to comment on PRs
  -  - for npm provenance

- Configure checkout action to use GitHub token with proper permissions
- Remove  flag that was preventing token use

## Problem

When running semantic-release, we were getting this error:



This was due to missing permissions for the GitHub token used in the workflow.