### PR TITLE
fix: resolve semantic-release version conflict

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,8 +34,13 @@ jobs:
       - name: Run tests
         run: npm test
 
+      - name: Fix package.json
+        run: npm run pkg:fix
+
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # Force semantic-release to use tags for version detection
+          SEMANTIC_RELEASE_USE_TAGS: "true"
         run: npx semantic-release

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,7 +1,18 @@
 {
   "branches": ["main"],
+  "tagFormat": "v${version}",
   "plugins": [
-    "@semantic-release/commit-analyzer",
+    ["@semantic-release/commit-analyzer", {
+      "preset": "angular",
+      "releaseRules": [
+        {"type": "docs", "scope": "README", "release": "patch"},
+        {"type": "refactor", "release": "patch"},
+        {"type": "style", "release": "patch"}
+      ],
+      "parserOpts": {
+        "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES"]
+      }
+    }],
     "@semantic-release/release-notes-generator",
     [
       "@semantic-release/changelog",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "test": "mocha tests/*.js",
     "lint": "eslint .",
     "example": "node examples/init.js",
-    "semantic-release": "semantic-release"
+    "semantic-release": "semantic-release",
+    "pkg:fix": "npm pkg fix"
   },
   "keywords": [
     "eslint",
@@ -38,7 +39,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cahaseler/eslint-plugin-vibe-check.git"
+    "url": "git+https://github.com/cahaseler/eslint-plugin-vibe-check.git"
   },
   "bugs": {
     "url": "https://github.com/cahaseler/eslint-plugin-vibe-check/issues"


### PR DESCRIPTION
## Description

This PR fixes the version conflict issue with semantic-release by ensuring it correctly determines the next version based on git tags.

## Changes

- Update semantic-release config with more detailed version rules
- Add tagFormat to ensure proper tag format matching (v)
- Fix repository URL in package.json to match npm expectations
- Add pkg:fix script to fix package.json automatically
- Force semantic-release to use tags for version detection with SEMANTIC_RELEASE_USE_TAGS env var
- Run npm pkg:fix before release to avoid npm auto-correction warnings

## Problem

When running semantic-release, we were getting this error:

Unknown command: "error"

To see a list of supported npm commands, run:
  npm help

This was due to semantic-release trying to publish with the same version number that already exists on npm.