### PR TITLE
Fix: Add support for legacy ESLint plugin format

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ npm install eslint-plugin-vibe-check --save-dev
 - Node.js >=20.8.1
 - ESLint >=8.0.0
 
+### Compatibility
+
+This plugin supports both:
+- **ESLint Flat Config** (modern format using `eslint.config.js`)
+- **Legacy ESLint Config** (traditional format using `.eslintrc.*` files)
+
 ## Usage
 
 ### Traditional Config (`.eslintrc`)

--- a/lib/index.cjs
+++ b/lib/index.cjs
@@ -1,0 +1,51 @@
+/**
+ * @fileoverview ESLint rules to provide warnings and guardrails for AI coding assistance
+ * @author eslint-plugin-vibe-check
+ */
+
+'use strict';
+
+// Export for CommonJS/Legacy ESLint
+// Note: This is a CommonJS wrapper around the ESM module to ensure compatibility
+// with legacy ESLint configurations (.eslintrc)
+
+// Rule definitions - require instead of import
+const maxFileLines = require('./rules/max-file-lines.cjs');
+const noPlaceholderComments = require('./rules/no-placeholder-comments.cjs');
+const noHardcodedCredentials = require('./rules/no-hardcoded-credentials.cjs');
+const noChangelogComments = require('./rules/no-changelog-comments.cjs');
+const neverAssume = require('./rules/never-assume.cjs');
+
+// Legacy ESLint format has rules directly on exports
+module.exports = {
+  rules: {
+    'max-file-lines': maxFileLines,
+    'no-placeholder-comments': noPlaceholderComments,
+    'no-hardcoded-credentials': noHardcodedCredentials,
+    'no-changelog-comments': noChangelogComments,
+    'never-assume': neverAssume,
+  },
+  // Legacy configs
+  configs: {
+    recommended: {
+      plugins: ['vibe-check'],
+      rules: {
+        'vibe-check/max-file-lines': 'warn',
+        'vibe-check/no-placeholder-comments': 'warn',
+        'vibe-check/no-hardcoded-credentials': 'warn',
+        'vibe-check/no-changelog-comments': 'warn',
+        'vibe-check/never-assume': 'error',
+      },
+    },
+    strict: {
+      plugins: ['vibe-check'],
+      rules: {
+        'vibe-check/max-file-lines': 'error',
+        'vibe-check/no-placeholder-comments': 'error',
+        'vibe-check/no-hardcoded-credentials': 'error',
+        'vibe-check/no-changelog-comments': 'error',
+        'vibe-check/never-assume': 'error',
+      },
+    },
+  },
+};

--- a/lib/rules/max-file-lines.cjs
+++ b/lib/rules/max-file-lines.cjs
@@ -1,0 +1,55 @@
+/**
+ * @fileoverview Rule to flag files that exceed a maximum line count
+ */
+
+'use strict';
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'enforce a maximum file length',
+      category: 'Best Practices',
+      recommended: true,
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          max: {
+            type: 'integer',
+            minimum: 0,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      tooManyLines: 'File has too many lines ({{count}}). Maximum allowed is {{max}} lines. Large files can be difficult to understand, maintain, and may exceed AI context windows.',
+    },
+  },
+
+  create(context) {
+    const sourceCode = context.getSourceCode();
+    const option = context.options[0] || {};
+    const maxLines = typeof option.max !== 'undefined' ? option.max : 400;
+
+    return {
+      Program(node) {
+        const lines = sourceCode.lines || sourceCode.getText().split('\n');
+        const lineCount = lines.length;
+
+        if (lineCount > maxLines) {
+          context.report({
+            node,
+            messageId: 'tooManyLines',
+            data: {
+              count: lineCount,
+              max: maxLines,
+            },
+          });
+        }
+      },
+    };
+  },
+};

--- a/lib/rules/never-assume.cjs
+++ b/lib/rules/never-assume.cjs
@@ -1,0 +1,52 @@
+/**
+ * @fileoverview Rule to flag comments that contain forms of the word "assume"
+ */
+
+'use strict';
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Disallow comments containing assumptions',
+      category: 'Best Practices',
+      recommended: true,
+    },
+    schema: [], // no options
+    messages: {
+      assumption: 'Never make assumptions about the codebase. Check and validate before making decisions.',
+    },
+  },
+
+  create(context) {
+    const assumptionTerms = [
+      'assume',
+      'assumes',
+      'assumed',
+      'assuming',
+      'assumption',
+      'assumptions',
+    ];
+
+    // Regular expression to match any of the assumption terms
+    const assumptionRegex = new RegExp(`\\b(${assumptionTerms.join('|')})\\b`, 'i');
+
+    return {
+      Program() {
+        const comments = context.getSourceCode().getAllComments();
+        
+        comments.forEach(comment => {
+          const commentText = comment.value.trim().toLowerCase();
+          
+          // Check if comment contains any assumption terms
+          if (assumptionRegex.test(commentText)) {
+            context.report({
+              node: comment,
+              messageId: 'assumption',
+            });
+          }
+        });
+      }
+    };
+  }
+};

--- a/lib/rules/no-changelog-comments.cjs
+++ b/lib/rules/no-changelog-comments.cjs
@@ -1,0 +1,84 @@
+/**
+ * @fileoverview Rule to flag changelog-like comments that explain code changes
+ */
+
+'use strict';
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Disallow changelog-like comments in code',
+      category: 'Best Practices',
+      recommended: true,
+    },
+    schema: [], // no options
+    messages: {
+      changelogComment: 'Changelog-like comments should not be left in code. Consider removing this comment.',
+    },
+    fixable: 'code',
+  },
+
+  create(context) {
+    const changelogTerms = [
+      'ensured',
+      'ensure',
+      'changed',
+      'updated',
+      'added',
+      'removed',
+      'fixed',
+      'improved',
+      'implemented',
+      'refactored',
+      'optimized',
+      'replaced',
+      'deleted',
+      'modified',
+      'enhanced',
+      'introduced',
+      'resolved',
+      'addressed',
+    ];
+
+    // Regular expression to match any of the changelog terms
+    const changelogRegex = new RegExp(`\\b(${changelogTerms.join('|')})\\b`, 'i');
+
+    return {
+      Program() {
+        const comments = context.getSourceCode().getAllComments();
+        
+        comments.forEach(comment => {
+          const commentText = comment.value.trim().toLowerCase();
+          
+          // Check if comment contains any changelog terms
+          if (changelogRegex.test(commentText)) {
+            context.report({
+              node: comment,
+              messageId: 'changelogComment',
+              fix(fixer) {
+                const sourceCode = context.getSourceCode();
+                const commentText = sourceCode.getText(comment);
+                
+                // Check if this is a JSX comment (wrapped in curly braces)
+                const parentToken = sourceCode.getTokenBefore(comment);
+                const nextToken = sourceCode.getTokenAfter(comment);
+                
+                // If comment is preceded by '{' and followed by '}', it's a JSX comment
+                if (parentToken && nextToken && 
+                    parentToken.value === '{' && nextToken.value === '}') {
+                  // Get the range of the entire expression including braces
+                  const range = [parentToken.range[0], nextToken.range[1]];
+                  return fixer.removeRange(range);
+                }
+                
+                // Regular comment handling
+                return fixer.remove(comment);
+              }
+            });
+          }
+        });
+      }
+    };
+  }
+};

--- a/lib/rules/no-hardcoded-credentials.cjs
+++ b/lib/rules/no-hardcoded-credentials.cjs
@@ -1,0 +1,263 @@
+/**
+ * @fileoverview Rule to detect hardcoded credentials, API keys, and secrets
+ * @author Claude
+ */
+
+'use strict';
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description: "Detect hardcoded credentials, API keys, and secrets",
+      category: "Security",
+      recommended: true,
+    },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          additionalPatterns: {
+            type: "array",
+            items: {
+              type: "string",
+            },
+          },
+          excludePatterns: {
+            type: "array",
+            items: {
+              type: "string",
+            },
+          }
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      hardcodedCredential: "Potential hardcoded credential detected: {{ name }}. Store sensitive information in environment variables or a secure vault."
+    }
+  },
+
+  create(context) {
+    const options = context.options[0] || {};
+    
+    // Default patterns for credential-like variable names
+    const defaultKeyPatterns = [
+      "[a-z]*[_-]?api[_-]?key",
+      "[a-z]*[_-]?secret",
+      "[a-z]*[_-]?password",
+      "[a-z]*[_-]?token",
+      "[a-z]*[_-]?auth",
+      "[a-z]*[_-]?credential",
+      "[a-z]*[_-]?access[_-]?key",
+      "[a-z]*[_-]?client[_-]?secret",
+      "[a-z]*[_-]?jwt",
+      "private[_-]?key",
+      "oauth[_-]?token",
+      "session[_-]?secret",
+      "ssn",
+      "social[_-]?security",
+      "passcode",
+      "encryption[_-]?key",
+      "aws[_-]?key",
+      "firebase[_-]?key",
+      "github[_-]?token",
+      "slack[_-]?token",
+      "stripe[_-]?key"
+    ];
+    
+    // Patterns that may indicate an actual hardcoded API key or credential
+    const valuePatterns = [
+      // Hex-looking strings (typically 32+ chars)
+      "^[a-f0-9]{32,}$",
+      // Base64-looking strings (typically 24+ chars)
+      "^[A-Za-z0-9+/=]{24,}$",
+      // JWT-like pattern
+      "^ey[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+$",
+      // API key patterns
+      "^key-[a-zA-Z0-9]{16,}$",
+      "^[a-zA-Z0-9]{16,}-[a-zA-Z0-9]{16,}$",
+      "^sk_[a-zA-Z0-9]{24,}$",
+      "^pk_[a-zA-Z0-9]{24,}$",
+      "^AIza[0-9A-Za-z-_]{35}$", // Google API keys
+      "^ghp_[a-zA-Z0-9]{36}$", // GitHub personal access tokens
+      "^[a-zA-Z0-9]{40}$", // GitHub, AWS
+      "^AKIA[0-9A-Z]{16}$", // AWS access key
+      "^xox[baprs]-[0-9A-Za-z-]{10,48}$" // Slack tokens
+    ];
+    
+    // Common environment variable patterns (to exclude)
+    const defaultExcludePatterns = [
+      "^process\\.env\\.\\w+$",
+      "^env\\.\\w+$",
+      "^config\\.\\w+$",
+      "^\\$\\{.+\\}$", // Template strings for env vars
+      "^'\\${\\w+}'$",
+      "^\"\\${\\w+}\"$",
+      "^'?<%=\\s*\\w+\\s*%>'?$" // Template engine vars
+    ];
+    
+    // Combine default patterns and additional patterns
+    const keyPatterns = [
+      ...defaultKeyPatterns,
+      ...(options.additionalPatterns || [])
+    ].map(pattern => new RegExp(pattern, "i"));
+    
+    const excludePatterns = [
+      ...defaultExcludePatterns,
+      ...(options.excludePatterns || [])
+    ].map(pattern => new RegExp(pattern));
+    
+    const valueRegexPatterns = valuePatterns.map(pattern => new RegExp(pattern));
+    
+    /**
+     * Check if a variable name looks like a credential
+     * @param {string} name - The variable name
+     * @returns {boolean} True if the name matches credential patterns
+     */
+    function isCredentialName(name) {
+      return keyPatterns.some(pattern => pattern.test(name));
+    }
+    
+    /**
+     * Check if a value looks like it might be a credential
+     * @param {string} value - The string value
+     * @returns {boolean} True if the value matches credential patterns
+     */
+    function isCredentialValue(value) {
+      // Exclude empty strings, very short strings, and numeric-only values
+      if (!value || typeof value !== 'string' || value.length < 8 || /^[0-9]+$/.test(value)) {
+        return false;
+      }
+      
+      // Check if the value matches any of our exclude patterns
+      if (excludePatterns.some(pattern => pattern.test(value))) {
+        return false;
+      }
+      
+      // Check if the value looks like an API key or credential by pattern
+      return valueRegexPatterns.some(pattern => pattern.test(value));
+    }
+    
+    /**
+     * Process template literals to check if they're using environment variables
+     * @param {Object} node - Template literal node
+     * @returns {boolean} True if this is an env var template
+     */
+    function isEnvVarTemplate(node) {
+      if (node.type !== 'TemplateLiteral') return false;
+      
+      // Check if it's a simple template with one expression
+      if (node.expressions.length === 1 && node.quasis.length === 2) {
+        const expr = node.expressions[0];
+        
+        // Check if it's accessing process.env or similar
+        if (expr.type === 'MemberExpression') {
+          let objName = '';
+          
+          if (expr.object.type === 'Identifier') {
+            objName = expr.object.name;
+          } else if (expr.object.type === 'MemberExpression' && 
+                     expr.object.object.type === 'Identifier' &&
+                     expr.object.property.type === 'Identifier') {
+            objName = `${expr.object.object.name}.${expr.object.property.name}`;
+          }
+          
+          return objName === 'process.env' || objName === 'env' || objName === 'config';
+        }
+      }
+      
+      return false;
+    }
+    
+    /**
+     * Check if a node has a sensitive name or value
+     * @param {Object} node - The AST node
+     * @param {string} name - The variable name
+     * @param {*} value - The variable value
+     */
+    function checkNode(node, name, value) {
+      // Check variable name against patterns
+      const isSensitiveName = isCredentialName(name);
+      
+      // For string literals, check if the value looks like a credential
+      const hasCredentialValue = typeof value === 'string' && isCredentialValue(value);
+      
+      // If either the name or value matches our patterns, report it
+      if (isSensitiveName || hasCredentialValue) {
+        context.report({
+          node,
+          messageId: "hardcodedCredential",
+          data: {
+            name: name
+          }
+        });
+      }
+    }
+    
+    return {
+      // Variable declarations (var, let, const)
+      VariableDeclarator(node) {
+        if (!node.init) return;
+        
+        const varName = node.id.name;
+        
+        // Skip checking if it's a template literal with environment variables
+        if (node.init.type === "TemplateLiteral" && isEnvVarTemplate(node.init)) {
+          return;
+        }
+        
+        if (node.init.type === "Literal" || node.init.type === "TemplateLiteral") {
+          const value = node.init.type === "Literal" ? node.init.value : 
+                        (node.init.quasis && node.init.quasis.length === 1) ? 
+                          node.init.quasis[0].value.raw : null;
+          
+          checkNode(node, varName, value);
+        }
+      },
+      
+      // Object properties (for objects that might contain credentials)
+      Property(node) {
+        if (node.key && node.value && node.value.type === "Literal") {
+          let propName = "";
+          
+          if (node.key.type === "Identifier") {
+            propName = node.key.name;
+          } else if (node.key.type === "Literal") {
+            propName = String(node.key.value);
+          }
+          
+          if (propName) {
+            checkNode(node, propName, node.value.value);
+          }
+        }
+      },
+      
+      // Assignment expressions (x = "abc")
+      AssignmentExpression(node) {
+        if (node.right && node.right.type === "Literal") {
+          let varName = "";
+          
+          if (node.left.type === "Identifier") {
+            varName = node.left.name;
+          } else if (node.left.type === "MemberExpression" && node.left.property) {
+            if (node.left.property.type === "Identifier") {
+              varName = node.left.property.name;
+            } else if (node.left.property.type === "Literal") {
+              varName = String(node.left.property.value);
+            }
+          }
+          
+          if (varName) {
+            checkNode(node, varName, node.right.value);
+          }
+        }
+      }
+    };
+  }
+};

--- a/lib/rules/no-placeholder-comments.cjs
+++ b/lib/rules/no-placeholder-comments.cjs
@@ -1,0 +1,95 @@
+/**
+ * @fileoverview Rule to detect placeholder comments that indicate code shortcuts
+ * @author Claude
+ */
+
+'use strict';
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description: "Detect placeholder comments that indicate code shortcuts",
+      category: "Best Practices",
+      recommended: true,
+    },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          patterns: {
+            type: "array",
+            items: {
+              type: "string",
+            },
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      placeholderComment: "Avoid placeholder comments: '{{ comment }}'. Replace with actual implementation."
+    }
+  },
+
+  create(context) {
+    const sourceCode = context.getSourceCode();
+    const options = context.options[0] || {};
+    
+    // Default patterns to look for
+    const defaultPatterns = [
+      "if this was a real app",
+      "if this were a real app", 
+      "in a real app",
+      "in production",
+      "todo: make secure",
+      "in a production environment",
+      "add proper error handling",
+      "implement security",
+      "fix later",
+      "should be implemented",
+      "needs implementation",
+      "in a real world scenario",
+      "this is just for demo",
+      "this is just a demo",
+      "in real code",
+      "placeholder",
+      "dummy implementation"
+    ];
+    
+    const patterns = options.patterns || defaultPatterns;
+    
+    // Create case-insensitive regex patterns
+    const regexPatterns = patterns.map(pattern => 
+      new RegExp(`\\b${pattern.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&')}\\b`, "i")
+    );
+
+    return {
+      Program() {
+        const comments = sourceCode.getAllComments();
+        
+        comments.forEach(comment => {
+          const commentText = comment.value.toLowerCase().trim();
+          
+          for (const pattern of regexPatterns) {
+            if (pattern.test(commentText)) {
+              context.report({
+                loc: comment.loc,
+                messageId: "placeholderComment",
+                data: {
+                  comment: comment.value.trim()
+                }
+              });
+              break;
+            }
+          }
+        });
+      }
+    };
+  }
+};

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "eslint-plugin-vibe-check",
   "description": "ESLint rules to provide warnings and guardrails for AI coding assistance",
-  "main": "lib/index.js",
+  "main": "lib/index.cjs",
+  "module": "lib/index.js",
   "type": "module",
   "exports": {
     ".": {
       "import": "./lib/index.js",
-      "require": "./lib/index.js"
+      "require": "./lib/index.cjs"
     },
     "./eslint.config.js": "./eslint.config.js",
     "./eslint.config.strict.js": "./eslint.config.strict.js"

--- a/tests/dual-format-test.js
+++ b/tests/dual-format-test.js
@@ -1,0 +1,64 @@
+/**
+ * @fileoverview Tests for both ESM and CommonJS versions of the plugin
+ */
+
+'use strict';
+
+import { strict as assert } from 'node:assert';
+import { beforeEach, describe, it } from 'node:test';
+
+import esmPlugin from '../lib/index.js';
+
+// Use dynamic import to test the CommonJS version (converted at runtime)
+const getCjsPlugin = async () => {
+  try {
+    // This import will convert from .cjs to module format
+    return await import('../lib/index.cjs');
+  } catch (error) {
+    console.error('Failed to load CommonJS version:', error);
+    throw error;
+  }
+};
+
+describe('Dual plugin format support', async () => {
+  let cjsPlugin;
+
+  beforeEach(async () => {
+    cjsPlugin = await getCjsPlugin();
+  });
+
+  it('ESM plugin has correct structure', () => {
+    assert.ok(esmPlugin.rules, 'ESM version should have rules property');
+    assert.ok(esmPlugin.configs, 'ESM version should have configs property');
+    
+    // Check that each rule exists in ESM version
+    assert.ok(esmPlugin.rules['max-file-lines'], 'max-file-lines rule should exist in ESM version');
+    assert.ok(esmPlugin.rules['no-placeholder-comments'], 'no-placeholder-comments rule should exist in ESM version');
+    assert.ok(esmPlugin.rules['no-hardcoded-credentials'], 'no-hardcoded-credentials rule should exist in ESM version');
+    assert.ok(esmPlugin.rules['no-changelog-comments'], 'no-changelog-comments rule should exist in ESM version');
+    assert.ok(esmPlugin.rules['never-assume'], 'never-assume rule should exist in ESM version');
+    
+    // Check recommended configs
+    assert.ok(esmPlugin.configs.recommended, 'recommended config should exist in ESM version');
+    assert.ok(esmPlugin.configs.strict, 'strict config should exist in ESM version');
+  });
+
+  it('CommonJS plugin has correct structure', () => {
+    // Note: ESM dynamic import of CJS module will wrap with a default property
+    const cjsPluginObj = cjsPlugin.default || cjsPlugin;
+    
+    assert.ok(cjsPluginObj.rules, 'CJS version should have rules property');
+    assert.ok(cjsPluginObj.configs, 'CJS version should have configs property');
+    
+    // Check that each rule exists in CJS version
+    assert.ok(cjsPluginObj.rules['max-file-lines'], 'max-file-lines rule should exist in CJS version');
+    assert.ok(cjsPluginObj.rules['no-placeholder-comments'], 'no-placeholder-comments rule should exist in CJS version');
+    assert.ok(cjsPluginObj.rules['no-hardcoded-credentials'], 'no-hardcoded-credentials rule should exist in CJS version');
+    assert.ok(cjsPluginObj.rules['no-changelog-comments'], 'no-changelog-comments rule should exist in CJS version');
+    assert.ok(cjsPluginObj.rules['never-assume'], 'never-assume rule should exist in CJS version');
+    
+    // Check recommended configs
+    assert.ok(cjsPluginObj.configs.recommended, 'recommended config should exist in CJS version');
+    assert.ok(cjsPluginObj.configs.strict, 'strict config should exist in CJS version');
+  });
+});


### PR DESCRIPTION
## Summary
- Add dual module format support for both ESM (modern) and CommonJS (legacy)
- Ensure compatibility with traditional \ configurations in addition to flat config
- Fix issue reported regarding legacy ESLint plugin formats not working properly

## Test plan
- Added new test file \ to validate both ESM and CommonJS exports
- Verified all existing tests pass with the new dual-format approach
- Checked both plugin formats with linting to ensure they work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)