### PR TITLE
fix: correct Claude CLI usage in autofix workflow

### DIFF
--- a/.github/workflows/claude_autofix.yml
+++ b/.github/workflows/claude_autofix.yml
@@ -84,7 +84,7 @@ jobs:
           # -p (--print): Run query and exit immediately
           # --verbose: Show detailed logging
           # --allowedTools: Specify permitted tools to use
-          CLAUDE_OUTPUT=$(claude -p --prompt-file claude_prompt.txt --verbose \
+          CLAUDE_OUTPUT=$(cat claude_prompt.txt | claude -p --verbose \
             --allowedTools "Bash(git diff:*)" "Bash(git log:*)" "Bash(npm:*)" "Edit" "Read" "Glob" "Grep" \
             --json)
           


### PR DESCRIPTION
## Summary
- Fixed bug in the Claude Autofix GitHub Action workflow
- Replaced incorrect  flag with proper pipe input method ()
- This ensures the Claude CLI processes input files correctly

## Test plan
- The workflow should now be able to run Claude Code with the prompt file content properly piped in